### PR TITLE
Expose sys_mtk via prob.f.sys in Strang solver

### DIFF
--- a/src/solver_strategy_strang.jl
+++ b/src/solver_strategy_strang.jl
@@ -158,7 +158,10 @@ function ODEProblem(s::CoupledSystem, st::SolverStrang; u0 = nothing, tspan = no
         kwargs = filter((p -> p.first ≠ :callback), kwargs)
     end
 
-    ODEProblem(nonstiff_op, view(u0, :), (start, finish), p; callback = CallbackSet(cb...),
+    # Attach sys_mtk so that users can query unknowns(prob.f.sys) to get the
+    # variable ordering that matches prob.u0 (same ordering as init_u uses).
+    nonstiff_fn = ODEFunction(nonstiff_op; sys = sys_mtk)
+    ODEProblem(nonstiff_fn, view(u0, :), (start, finish), p; callback = CallbackSet(cb...),
         dt = st.timestep, kwargs...)
 end
 


### PR DESCRIPTION
Wrap nonstiff_op in ODEFunction(nonstiff_op; sys=sys_mtk) before passing to ODEProblem, so that users can query unknowns(prob.f.sys) to determine the variable ordering that matches prob.u0.

This allows downstream code to programmatically discover which state index corresponds to which species, without relying on fragile fingerprint-matching hacks against default initial conditions.

The change has zero runtime cost since ODEProblem already wraps raw operators in ODEFunction internally; this simply makes it explicit and attaches the symbolic system metadata.