### PR TITLE
Support (event, ics) tuple return from sys_event functions

### DIFF
--- a/src/coupled_system.jl
+++ b/src/coupled_system.jl
@@ -215,7 +215,19 @@ function Base.convert(::Type{<:System}, sys::CoupledSystem; name = :model, compi
             initial_conditions = ics, kwargs...)
         temp_sys = mtkcompile(ModelingToolkit.flatten(compose(
             temp_connectors, systems...)))
-        de = filter(!isnothing, [f(temp_sys) for f in discrete_event_fs])
+        results = [f(temp_sys) for f in discrete_event_fs]
+        de = []
+        for r in results
+            if isnothing(r)
+                continue
+            elseif r isa Tuple
+                # sys_event returned (event, initial_conditions_dict).
+                push!(de, r[1])
+                merge!(ics, r[2])
+            else
+                push!(de, r)
+            end
+        end
 
         # Create system of connectors and events.
         connectors = System(connector_eqs, iv; name = name,


### PR DESCRIPTION
## Summary
- When a `sys_event` function returns a `Tuple`, treat it as `(event, initial_conditions_dict)` and merge the initial conditions into the system
- This allows system events to provide initial conditions for discrete variables they manage
- Needed by EarthSciData's `create_updater_sys_event` which returns `(event, ics)` to set initial values for data array discretes

## Test plan
- [ ] Existing tests pass (no behavior change for non-tuple returns)
- [ ] Verify with EarthSciData coupled system tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)