### PR TITLE
Skip already-spatial variables in add_dims

### DIFF
--- a/src/add_dims.jl
+++ b/src/add_dims.jl
@@ -6,8 +6,11 @@ add_dims(equation, vars, dims)
 
 Add the given dimensions to each variable in `vars` in the given expression
 or equation.
-Each variable in `vars` must be unidimensional, i.e.
-defined like `@variables u(t)` rather than `@variables u(..)`.
+
+Variables that already have multiple dimensions (i.e., defined like
+`@variables v(..)` and called as `v(t, x, y)`) are left unchanged.
+This allows components that construct spatially-varying variables directly
+to be composed with components that rely on automatic dimension expansion.
 
 # Example:
 
@@ -28,6 +31,7 @@ function add_dims(exp, vars::AbstractVector, dims::AbstractVector)
     newvars = add_dims(vars, dims)
     @variables 🦖🌋temp # BUG(CT): If someone chooses 🦖🌋temp as a variable in their equation this will fail.
     for (var, newvar) in zip(vars, newvars)
+        isequal(var, newvar) && continue # Skip already-spatial variables.
         # Replace variable with temporary variable, then replace temporary
         # variable with new variable.
         # TODO(CT): Should be able to directly substitute all variables at once but doesn't work.
@@ -38,12 +42,18 @@ function add_dims(exp, vars::AbstractVector, dims::AbstractVector)
 end
 
 function add_dims(vars::AbstractVector, dims::AbstractVector)
-    syms = [Symbolics.tosymbol(x, escape = false) for x in vars]
     o = Num[]
-    for (sym, var) in zip(syms, vars)
-        newvar = (@variables $sym(..))[1]
-        newvar = add_metadata(newvar, var)
-        push!(o, newvar(dims...))
+    for var in vars
+        nargs = length(Symbolics.arguments(Symbolics.unwrap(var)))
+        if nargs > 1
+            # Variable already has spatial dimensions — keep it as-is.
+            push!(o, var)
+        else
+            sym = Symbolics.tosymbol(var, escape = false)
+            newvar = (@variables $sym(..))[1]
+            newvar = add_metadata(newvar, var)
+            push!(o, newvar(dims...))
+        end
     end
     return o
 end

--- a/test/add_dims_test.jl
+++ b/test/add_dims_test.jl
@@ -43,3 +43,45 @@ end
 
     @test isequal(result, wanteq)
 end
+
+@testset "Skip already-spatial variables" begin
+    @variables v(..)
+    v_spatial = v(t, x, y)
+
+    result = EarthSciMLBase.add_dims([u, v_spatial], [x, y, t])
+    @test length(result) == 2
+    # u(t) should be expanded to u(x, y, t)
+    @test length(Symbolics.arguments(Symbolics.unwrap(result[1]))) == 3
+    # v(t, x, y) should be unchanged
+    @test isequal(result[2], v_spatial)
+end
+
+@testset "Skip already-spatial in expression" begin
+    @variables v(..)
+    v_spatial = v(t, x, y)
+
+    exp = 2u + 3k * v_spatial + 1
+
+    wantexp = let
+        @variables u(..) v(..)
+        2u(x, y, t) + 3k * v(t, x, y) + 1
+    end
+
+    result = EarthSciMLBase.add_dims(exp, [u, v_spatial], [x, y, t])
+    @test isequal(result, wantexp)
+end
+
+@testset "Skip already-spatial in equation" begin
+    @variables v(..)
+    v_spatial = v(t, x, y)
+
+    eq_mixed = D(u) ~ k * v_spatial
+
+    wanteq = let
+        @variables u(..) v(..)
+        D(u(x, y, t)) ~ k * v(t, x, y)
+    end
+
+    result = EarthSciMLBase.add_dims(eq_mixed, [u, v_spatial], [x, y, t])
+    @test isequal(result, wanteq)
+end


### PR DESCRIPTION
## Summary
- Modify `add_dims` to detect variables that already have multiple dimensions and leave them unchanged
- Variables with >1 argument (e.g., `v(t, x, y)`) are considered already spatial and skipped
- Variables with 1 argument (e.g., `u(t)`) are expanded as before

## Motivation
This enables components that construct spatially-varying variables directly (using `pvars(domaininfo)` in their constructors) to be composed with components that rely on automatic dimension expansion via `DomainInfo`. Without this change, `add_dims` would attempt to double-expand already-spatial variables, causing errors.

This is needed for wildfire spread modeling where PDE components (level-set fire front) need spatial derivatives in their equations from the start, while algebraic components (Rothermel spread rate) can use automatic expansion.

## Changes
- `add_dims(vars, dims)`: Check `length(Symbolics.arguments(Symbolics.unwrap(var)))` — if >1, push variable unchanged
- `add_dims(exp, vars, dims)`: Skip substitution loop for variables where `isequal(var, newvar)` (unchanged by expansion)

## Test plan
- [x] Existing tests pass unchanged (3 tests)
- [x] New test: skip already-spatial variables in variable list
- [x] New test: skip already-spatial variables in mixed expression
- [x] New test: skip already-spatial variables in mixed equation

🤖 Generated with [Claude Code](https://claude.com/claude-code)