### PR TITLE
Add param_to_var support for PDESystem

### DIFF
--- a/src/param_to_var.jl
+++ b/src/param_to_var.jl
@@ -59,3 +59,49 @@ function param_to_var(sys::ModelingToolkit.AbstractSystem, ps::Symbol...)
         defaults = defaults
     )
 end
+
+"""
+Replace the parameter(s) `ps` in a `PDESystem` with new time-dependent variable(s)
+that have the same name, units, and description.
+
+$(SIGNATURES)
+
+Since `PDESystem` does not support `SymbolicUtils.substitute`, this method manually
+substitutes in all equations and boundary conditions, then reconstructs the `PDESystem`.
+"""
+function param_to_var(sys::ModelingToolkit.PDESystem, ps::Symbol...)
+    params = sys.ps
+    replace = Dict()
+    for p in ps
+        dv_names = [Symbolics.tosymbol(dv, escape = false) for dv in sys.dvs]
+        if p in dv_names
+            continue
+        end
+        iparam = findfirst(isequal(p), Symbol.(params))
+        @assert !isnothing(iparam) "Parameter `$p` not found in the PDESystem parameters $(Symbol.(params))"
+        param = params[iparam]
+
+        iv = first(sys.ivs)  # Use the first independent variable (typically t)
+        newvar = only(@variables $p(iv))
+        newvar = add_metadata(newvar, param; exclude_default = true)
+        replace[Symbolics.unwrap(param)] = Symbolics.unwrap(newvar)
+    end
+
+    if isempty(replace)
+        return sys
+    end
+
+    # Manually substitute in equations and boundary conditions
+    new_eqs = map(sys.eqs) do eq
+        Symbolics.substitute(eq.lhs, replace) ~ Symbolics.substitute(eq.rhs, replace)
+    end
+    new_bcs = map(sys.bcs) do bc
+        Symbolics.substitute(bc.lhs, replace) ~ Symbolics.substitute(bc.rhs, replace)
+    end
+
+    # Remove converted parameters
+    new_ps = [p for p in params if !(Symbolics.unwrap(p) in keys(replace))]
+
+    PDESystem(new_eqs, new_bcs, sys.domain, sys.ivs, sys.dvs, new_ps;
+        name = nameof(sys), metadata = sys.metadata)
+end

--- a/test/param_to_var_test.jl
+++ b/test/param_to_var_test.jl
@@ -54,3 +54,60 @@ end
     sys3 = EarthSciMLBase.param_to_var(sys2, :β)
     @test isequal(sys2, sys3)
 end
+
+@testset "PDESystem param_to_var" begin
+    using DomainSets
+
+    @parameters px [unit = u"m"]
+    @parameters py [unit = u"m"]
+    @parameters S = 1.0 [description = "S description", unit = u"m/s"]
+    @variables ψ(..) [description = "Level-set function", unit = u"m"]
+    Dpx = Differential(px)
+    Dpy = Differential(py)
+
+    pde_eq = [D(ψ(t, px, py)) ~ -S * sqrt(Dpx(ψ(t, px, py))^2 + Dpy(ψ(t, px, py))^2)]
+    pde_bcs = [ψ(0.0, px, py) ~ sqrt((px - 50.0)^2 + (py - 50.0)^2) - 10.0]
+    pde_domains = [t ∈ Interval(0.0, 10.0), px ∈ Interval(0.0, 100.0), py ∈ Interval(0.0, 100.0)]
+    pdesys = PDESystem(pde_eq, pde_bcs, pde_domains, [t, px, py], [ψ(t, px, py)], [S];
+        name = :pdetest, metadata = Dict(CoupleType => :pdemetatest))
+
+    pdesys2 = param_to_var(pdesys, :S)
+
+    # S should no longer be a parameter
+    @test length(pdesys2.ps) == 0
+
+    # The substituted equation should contain S(t) instead of S
+    @variables S(t) [unit = u"m/s", description = "S description"]
+    eq_vars = Symbolics.get_variables(equations(pdesys2)[1])
+    has_S_t = any(v -> Symbolics.tosymbol(v, escape = false) == :S, eq_vars)
+    @test has_S_t
+
+    # Metadata should be preserved
+    @test pdesys2.metadata[CoupleType] == :pdemetatest
+
+    # System structure should be preserved
+    @test length(equations(pdesys2)) == 1
+    @test length(pdesys2.bcs) == 1
+    @test length(pdesys2.ivs) == 3
+    @test length(pdesys2.dvs) == 1
+end
+
+@testset "PDESystem param_to_var - skip existing variable" begin
+    using DomainSets
+
+    @parameters px2 [unit = u"m"]
+    @parameters S2 = 1.0 [description = "S2 description", unit = u"m/s"]
+    @variables ψ2(..) [description = "ψ2", unit = u"m"]
+    @variables S2_var(..) [description = "S2 var", unit = u"m/s"]
+
+    pde_eq = [D(ψ2(t, px2)) ~ -S2 * Differential(px2)(ψ2(t, px2))]
+    pde_bcs = [ψ2(0.0, px2) ~ px2]
+    pde_domains = [t ∈ Interval(0.0, 10.0), px2 ∈ Interval(0.0, 100.0)]
+
+    # S2_var is already a DV — passing its symbol should be a no-op
+    pdesys = PDESystem(pde_eq, pde_bcs, pde_domains, [t, px2],
+        [ψ2(t, px2), S2_var(t, px2)], [S2]; name = :pdetest2)
+
+    pdesys2 = param_to_var(pdesys, :S2_var)  # already a DV, should skip
+    @test length(pdesys2.ps) == 1  # S2 still a parameter
+end


### PR DESCRIPTION
## Summary
- Add a specialized `param_to_var` method for `PDESystem` that manually substitutes parameters in equations and boundary conditions
- The existing method fails on PDESystem because `SymbolicUtils.substitute` and `ModelingToolkit.get_iv` are not supported for PDESystem
- Preserves metadata, boundary conditions, domain info, and dependent variables

## Test plan
- [x] New test: single parameter substitution on PDESystem with spatial derivatives
- [x] New test: skip existing DV names (no-op when symbol is already a dependent variable)
- [x] All existing param_to_var tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)