### PR TITLE
Support mixed-dimension PDE system coupling

### DIFF
--- a/src/coupled_system.jl
+++ b/src/coupled_system.jl
@@ -1,4 +1,4 @@
-export CoupledSystem, ConnectorSystem, couple, CoupleType, SysDiscreteEvent, merge_pdesystems
+export CoupledSystem, ConnectorSystem, couple, CoupleType, SysDiscreteEvent, merge_pdesystems, slice_variable
 
 """
 A system for composing together other systems using the [`couple`](@ref) function.

--- a/src/pdesystem_coupling.jl
+++ b/src/pdesystem_coupling.jl
@@ -1,45 +1,60 @@
 """
     $(SIGNATURES)
 
-Validate that all PDESystems have compatible independent variables and domains.
-Checks that all systems share the same set of independent variables (by name)
-and that their domain ranges match.
+Validate that all PDESystems have compatible domains and compute the union of
+their independent variables and domains.
+
+Systems may have different numbers of spatial dimensions (e.g., a 2D system
+coupled with a 3D system). For any independent variable that appears in
+multiple systems, the domain ranges must match. The returned IVs and domains
+are the union across all systems, preserving the order from the system with
+the most dimensions and appending any additional IVs from other systems.
+
+Returns `(unified_ivs, unified_domains)`.
 """
-function validate_compatible_domains(pdesystems::AbstractVector{<:ModelingToolkit.PDESystem})
-    length(pdesystems) <= 1 && return nothing
+function validate_and_unify_domains(pdesystems::AbstractVector{<:ModelingToolkit.PDESystem})
+    @assert !isempty(pdesystems) "At least one PDESystem is required."
 
-    ref = first(pdesystems)
-    ref_ivs = Set(Symbol.(ref.ivs))
-    ref_domains = ref.domain
+    if length(pdesystems) == 1
+        p = only(pdesystems)
+        return (p.ivs, p.domain)
+    end
 
-    for (k, pdesys) in enumerate(pdesystems)
-        k == 1 && continue
-        # Check independent variables match
-        ivs = Set(Symbol.(pdesys.ivs))
-        if ivs != ref_ivs
-            error("PDESystems must share the same independent variables. " *
-                  "System 1 has $(ref_ivs) but system $k has $(ivs).")
-        end
+    # Start from the system with the most IVs so that the ordering is natural.
+    sorted_idx = sortperm(pdesystems; by = p -> length(p.ivs), rev = true)
 
-        # Check domain ranges are compatible
-        if length(pdesys.domain) != length(ref_domains)
-            error("PDESystems must have the same number of domains. " *
-                  "System 1 has $(length(ref_domains)) but system $k has $(length(pdesys.domain)).")
-        end
-        for (i, (d1, d2)) in enumerate(zip(ref_domains, pdesys.domain))
-            v1 = Symbol(d1.variables)
-            v2 = Symbol(d2.variables)
-            if v1 != v2
-                error("Domain variable mismatch at position $i: $v1 vs $v2.")
-            end
-            lo1, hi1 = DomainSets.infimum(d1.domain), DomainSets.supremum(d1.domain)
-            lo2, hi2 = DomainSets.infimum(d2.domain), DomainSets.supremum(d2.domain)
-            if !(lo1 ≈ lo2) || !(hi1 ≈ hi2)
-                error("Domain range mismatch for $v1: [$lo1, $hi1] vs [$lo2, $hi2].")
+    seen = Set{Symbol}()
+    unified_ivs = []
+    unified_domains = []
+    # Maps Symbol => domain spec for validation of shared IVs.
+    domain_map = Dict{Symbol, Any}()
+
+    for k in sorted_idx
+        pdesys = pdesystems[k]
+        @assert length(pdesys.ivs) == length(pdesys.domain) "System $k has $(length(pdesys.ivs)) IVs but $(length(pdesys.domain)) domains."
+        for (iv, dom) in zip(pdesys.ivs, pdesys.domain)
+            sym = Symbol(iv)
+            if sym ∈ seen
+                # Validate domain range matches the first occurrence.
+                existing_dom = domain_map[sym]
+                lo1 = DomainSets.infimum(existing_dom.domain)
+                hi1 = DomainSets.supremum(existing_dom.domain)
+                lo2 = DomainSets.infimum(dom.domain)
+                hi2 = DomainSets.supremum(dom.domain)
+                if !(lo1 ≈ lo2) || !(hi1 ≈ hi2)
+                    error("Domain range mismatch for $sym: [$lo1, $hi1] vs [$lo2, $hi2] " *
+                          "(in system $k).")
+                end
+            else
+                push!(seen, sym)
+                push!(unified_ivs, iv)
+                push!(unified_domains, dom)
+                domain_map[sym] = dom
             end
         end
     end
-    nothing
+
+    return (unified_ivs, unified_domains)
 end
 
 """
@@ -83,7 +98,11 @@ end
 
 Merge multiple PDESystems into a single flat PDESystem.
 
-All input PDESystems must share the same independent variables and compatible domain ranges.
+Input PDESystems may have different numbers of spatial dimensions. For shared
+independent variables, domain ranges must match. The merged system uses the
+union of all independent variables and domains, and each dependent variable
+retains its original dimensions.
+
 Coupling equations are applied by matching LHS: if a coupling equation has the same LHS
 as an existing equation, its RHS is added to the existing equation's RHS. Otherwise, it
 is added as a new equation.
@@ -102,7 +121,7 @@ function merge_pdesystems(pdesystems::AbstractVector{<:ModelingToolkit.PDESystem
         return only(pdesystems)
     end
 
-    validate_compatible_domains(pdesystems)
+    unified_ivs, unified_domains = validate_and_unify_domains(pdesystems)
 
     # Collect all equations
     all_eqs = Equation[]
@@ -126,13 +145,51 @@ function merge_pdesystems(pdesystems::AbstractVector{<:ModelingToolkit.PDESystem
     all_ps = unique_syms(vcat(
         [_collect_ps(p.ps) for p in pdesystems]...))
 
-    # Use IVs and domains from the first system (validated compatible)
-    ivs = first(pdesystems).ivs
-    domains = first(pdesystems).domain
-
-    PDESystem(all_eqs, all_bcs, domains, ivs, all_dvs, all_ps; name = name)
+    PDESystem(all_eqs, all_bcs, unified_domains, unified_ivs, all_dvs, all_ps; name = name)
 end
 
 # Safely collect parameters, handling NullParameters from SciMLBase.
 _collect_ps(ps::AbstractVector) = ps
 _collect_ps(_) = Num[]  # Fallback for NullParameters or other non-iterable types
+
+"""
+    $(SIGNATURES)
+
+Create a lower-dimensional dependent variable by fixing one spatial dimension
+of a higher-dimensional variable at a specific value. This is useful for
+coupling systems with different numbers of spatial dimensions, e.g.,
+extracting ground-level data from a 3D atmospheric variable for use in a
+2D surface model.
+
+Returns `(new_dv, equation)` where `new_dv` is the sliced dependent variable
+(with the fixed dimension removed from its arguments) and `equation` defines
+`new_dv` in terms of the original variable evaluated at `slice_value`.
+
+# Arguments
+- `var`: A symbolic dependent variable call, e.g., `U(t, x, y, lev)`
+- `slice_dim`: The independent variable to fix, e.g., `lev`
+- `slice_value`: The numeric value at which to evaluate `slice_dim`
+
+# Example
+```julia
+@parameters x y lev
+@variables U(..)
+new_dv, eq = slice_variable(U(t, x, y, lev), lev, 1.0)
+# new_dv = U(t, x, y)
+# eq: U(t, x, y) ~ U(t, x, y, 1.0)
+```
+"""
+function slice_variable(var, slice_dim, slice_value)
+    args = Symbolics.arguments(Symbolics.unwrap(var))
+    op = Symbolics.operation(Symbolics.unwrap(var))
+    slice_sym = Symbol(slice_dim)
+
+    # Build new argument lists
+    reduced_args = [a for a in args if Symbol(a) != slice_sym]
+    fixed_args = [Symbol(a) == slice_sym ? slice_value : a for a in args]
+
+    new_dv = Symbolics.wrap(op)(reduced_args...)
+    fixed_var = Symbolics.wrap(op)(fixed_args...)
+
+    return (new_dv, new_dv ~ fixed_var)
+end

--- a/test/pdesystem_coupling_test.jl
+++ b/test/pdesystem_coupling_test.jl
@@ -10,7 +10,7 @@ import SciMLBase
 const t_test = t_nounits
 const D_test = D_nounits
 
-@testset "validate_compatible_domains" begin
+@testset "validate_and_unify_domains" begin
     @parameters x
     @variables u(..) v(..)
 
@@ -29,20 +29,36 @@ const D_test = D_nounits
         name = :pde2
     )
 
-    # Compatible domains should not error
-    @test isnothing(EarthSciMLBase.validate_compatible_domains([pde1, pde2]))
+    # Compatible same-dimension domains should succeed
+    ivs, doms = EarthSciMLBase.validate_and_unify_domains([pde1, pde2])
+    @test length(ivs) == 2  # t, x
+    @test length(doms) == 2
 
     # Incompatible domain range should error
     @parameters y
     @variables w(..)
-    pde3 = PDESystem(
-        [D_test(w(t_test, y)) ~ -w(t_test, y)],
-        [w(0, y) ~ 1.0, w(t_test, 0) ~ 0.0, w(t_test, 2) ~ 0.0],
-        [t_test ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 2.0)],
-        [t_test, y], [w(t_test, y)], [];
-        name = :pde3
+    pde_bad = PDESystem(
+        [D_test(w(t_test, x)) ~ -w(t_test, x)],
+        [w(0, x) ~ 1.0, w(t_test, 0) ~ 0.0, w(t_test, 2) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 2.0)],
+        [t_test, x], [w(t_test, x)], [];
+        name = :pde_bad
     )
-    @test_throws ErrorException EarthSciMLBase.validate_compatible_domains([pde1, pde3])
+    @test_throws ErrorException EarthSciMLBase.validate_and_unify_domains([pde1, pde_bad])
+
+    # Mixed dimensions: 1D (t, x) + 2D (t, x, y) should produce union (t, x, y)
+    pde_2d = PDESystem(
+        [D_test(w(t_test, x, y)) ~ -w(t_test, x, y)],
+        [w(0, x, y) ~ 1.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)],
+        [t_test, x, y], [w(t_test, x, y)], [];
+        name = :pde_2d
+    )
+    ivs, doms = EarthSciMLBase.validate_and_unify_domains([pde1, pde_2d])
+    @test length(ivs) == 3  # t, x, y (union)
+    @test length(doms) == 3
+    # Verify ordering: system with most IVs comes first, so t, x, y
+    @test Symbol.(ivs) == [:t, :x, :y]
 end
 
 @testset "unique_syms" begin
@@ -278,4 +294,172 @@ end
     @test length(equations(merged)) == 1
     @test length(merged.dvs) == 1
     @test length(merged.bcs) == 3
+end
+
+@testset "merge_pdesystems - mixed dimensions (2D + 3D)" begin
+    @parameters x y z
+    @parameters k
+    @variables u(..) v(..)
+
+    Dx = Differential(x)
+    Dy = Differential(y)
+    Dz = Differential(z)
+
+    # 2D system: u(t, x, y)
+    pde_2d = PDESystem(
+        [D_test(u(t_test, x, y)) ~ Dx(Dx(u(t_test, x, y))) + Dy(Dy(u(t_test, x, y)))],
+        [u(0, x, y) ~ 1.0,
+         u(t_test, 0, y) ~ 0.0, u(t_test, 1, y) ~ 0.0,
+         u(t_test, x, 0) ~ 0.0, u(t_test, x, 1) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)],
+        [t_test, x, y], [u(t_test, x, y)], [];
+        name = :pde_2d
+    )
+
+    # 3D system: v(t, x, y, z)
+    pde_3d = PDESystem(
+        [D_test(v(t_test, x, y, z)) ~ Dz(Dz(v(t_test, x, y, z))) - k * v(t_test, x, y, z)],
+        [v(0, x, y, z) ~ 0.0,
+         v(t_test, 0, y, z) ~ 0.0, v(t_test, 1, y, z) ~ 0.0,
+         v(t_test, x, 0, z) ~ 0.0, v(t_test, x, 1, z) ~ 0.0,
+         v(t_test, x, y, 0) ~ 0.0, v(t_test, x, y, 1) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0),
+         y ∈ Interval(0.0, 1.0), z ∈ Interval(0.0, 1.0)],
+        [t_test, x, y, z], [v(t_test, x, y, z)], [k];
+        name = :pde_3d
+    )
+
+    merged = merge_pdesystems([pde_2d, pde_3d])
+
+    @test length(equations(merged)) == 2
+    @test length(merged.dvs) == 2  # u and v
+    @test length(merged.ivs) == 4  # t, x, y, z (union)
+    @test length(merged.domain) == 4
+    @test length(merged.ps) == 1   # k
+
+    # Verify IVs are the union: t, x, y, z
+    iv_syms = Symbol.(merged.ivs)
+    @test :t ∈ iv_syms
+    @test :x ∈ iv_syms
+    @test :y ∈ iv_syms
+    @test :z ∈ iv_syms
+
+    # u should still be 2D (t, x, y) and v should be 3D (t, x, y, z)
+    dvs_str = string.(merged.dvs)
+    @test any(s -> occursin("u(t, x, y)", s), dvs_str)
+    @test any(s -> occursin("v(t, x, y, z)", s), dvs_str)
+end
+
+@testset "merge_pdesystems - mixed dims with coupling equations" begin
+    @parameters x y z
+    @variables u(..) v(..)
+
+    Dx = Differential(x)
+
+    # 2D system: u(t, x, y)
+    pde_2d = PDESystem(
+        [D_test(u(t_test, x, y)) ~ Dx(Dx(u(t_test, x, y)))],
+        [u(0, x, y) ~ 1.0,
+         u(t_test, 0, y) ~ 0.0, u(t_test, 1, y) ~ 0.0,
+         u(t_test, x, 0) ~ 0.0, u(t_test, x, 1) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)],
+        [t_test, x, y], [u(t_test, x, y)], [];
+        name = :pde_2d
+    )
+
+    # 3D system: v(t, x, y, z)
+    pde_3d = PDESystem(
+        [D_test(v(t_test, x, y, z)) ~ -v(t_test, x, y, z)],
+        [v(0, x, y, z) ~ 0.0,
+         v(t_test, 0, y, z) ~ 0.0, v(t_test, 1, y, z) ~ 0.0,
+         v(t_test, x, 0, z) ~ 0.0, v(t_test, x, 1, z) ~ 0.0,
+         v(t_test, x, y, 0) ~ 0.0, v(t_test, x, y, 1) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0),
+         y ∈ Interval(0.0, 1.0), z ∈ Interval(0.0, 1.0)],
+        [t_test, x, y, z], [v(t_test, x, y, z)], [];
+        name = :pde_3d
+    )
+
+    # Coupling: add v at z=0 to u's equation
+    coupling = [D_test(u(t_test, x, y)) ~ v(t_test, x, y, 0.0)]
+    merged = merge_pdesystems([pde_2d, pde_3d], coupling)
+
+    @test length(equations(merged)) == 2
+    @test length(merged.ivs) == 4  # t, x, y, z
+    # Verify coupling term was added to u's equation
+    u_eq = equations(merged)[findfirst(eq -> occursin("u(t, x, y)", string(eq.lhs)), equations(merged))]
+    @test occursin("v(t, x, y, 0.0)", string(u_eq.rhs))
+end
+
+@testset "slice_variable" begin
+    @parameters x y lev
+    @variables U(..)
+
+    new_dv, eq = slice_variable(U(t_test, x, y, lev), lev, 1.0)
+
+    # New DV should have lev removed
+    new_args = Symbolics.arguments(Symbolics.unwrap(new_dv))
+    @test length(new_args) == 3  # t, x, y
+    @test all(Symbol(a) != :lev for a in new_args)
+
+    # Equation RHS should have lev replaced with 1.0
+    @test occursin("1.0", string(eq.rhs))
+    # The equation should have the correct form
+    @test string(eq.lhs) == "U(t, x, y)"
+    @test string(eq.rhs) == "U(t, x, y, 1.0)"
+end
+
+@testset "couple() two PDESystems with mixed dimensions and CoupleType" begin
+    @parameters x y z
+    @variables u(..) v(..)
+    Dx = Differential(x)
+
+    struct MixedPDE2DCoupler
+        sys
+    end
+    struct MixedPDE3DCoupler
+        sys
+    end
+
+    pde_2d = PDESystem(
+        [D_test(u(t_test, x, y)) ~ Dx(Dx(u(t_test, x, y)))],
+        [u(0, x, y) ~ 1.0,
+         u(t_test, 0, y) ~ 0.0, u(t_test, 1, y) ~ 0.0,
+         u(t_test, x, 0) ~ 0.0, u(t_test, x, 1) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0), y ∈ Interval(0.0, 1.0)],
+        [t_test, x, y], [u(t_test, x, y)], [];
+        name = :pde_2d,
+        metadata = Dict(CoupleType => MixedPDE2DCoupler)
+    )
+
+    pde_3d = PDESystem(
+        [D_test(v(t_test, x, y, z)) ~ -v(t_test, x, y, z)],
+        [v(0, x, y, z) ~ 2.0,
+         v(t_test, 0, y, z) ~ 0.0, v(t_test, 1, y, z) ~ 0.0,
+         v(t_test, x, 0, z) ~ 0.0, v(t_test, x, 1, z) ~ 0.0,
+         v(t_test, x, y, 0) ~ 0.0, v(t_test, x, y, 1) ~ 0.0],
+        [t_test ∈ Interval(0.0, 1.0), x ∈ Interval(0.0, 1.0),
+         y ∈ Interval(0.0, 1.0), z ∈ Interval(0.0, 1.0)],
+        [t_test, x, y, z], [v(t_test, x, y, z)], [];
+        name = :pde_3d,
+        metadata = Dict(CoupleType => MixedPDE3DCoupler)
+    )
+
+    # Coupling: add ground-level v to u's equation
+    function EarthSciMLBase.couple2(a::MixedPDE3DCoupler, b::MixedPDE2DCoupler)
+        a_sys, b_sys = a.sys, b.sys
+        coupling_eqs = [D_test(u(t_test, x, y)) ~ v(t_test, x, y, 0.0)]
+        ConnectorSystem(coupling_eqs, a_sys, b_sys)
+    end
+
+    cs = couple(pde_2d, pde_3d)
+    merged = convert(PDESystem, cs)
+
+    @test length(equations(merged)) == 2
+    @test length(merged.ivs) == 4  # t, x, y, z
+    @test length(merged.dvs) == 2
+
+    # Verify coupling term in u's equation
+    u_eq = equations(merged)[findfirst(eq -> occursin("u(t, x, y)", string(eq.lhs)), equations(merged))]
+    @test occursin("v(t, x, y, 0.0)", string(u_eq.rhs))
 end


### PR DESCRIPTION
## Summary
- Replace `validate_compatible_domains` with `validate_and_unify_domains` to allow coupling PDESystems with different numbers of spatial dimensions (e.g., 2D fire spread + 3D atmospheric model)
- The merged system uses the union of all independent variables and domains; each dependent variable retains its original dimensions
- Add `slice_variable` utility for extracting lower-dimensional variables by fixing one spatial dimension at a specific value (e.g., ground-level data from a 3D system)

## Motivation
This enables coupling EarthSciData.WRF (3D: x, y, lev) with WildlandFire.LevelSetFireSpread (2D: x, y). The fire spread model only needs ground-level atmospheric data, so the systems have naturally different dimensionalities. MethodOfLines.jl already supports mixed-dimension DVs natively via per-variable CartesianIndices.

## Changes
- `src/pdesystem_coupling.jl`: New `validate_and_unify_domains` function that computes the union of IVs/domains while validating shared IV domain ranges match. Updated `merge_pdesystems` to use it. Added `slice_variable` utility.
- `src/coupled_system.jl`: Export `slice_variable`
- `test/pdesystem_coupling_test.jl`: Updated validation tests, added tests for mixed-dimension merging, coupling equations across dimensions, `slice_variable`, and end-to-end CoupleType dispatch with mixed dimensions.

## Test plan
- [x] All existing same-dimension coupling tests continue to pass (backward compatible)
- [x] New `validate_and_unify_domains` tests: union computation, error on mismatched ranges
- [x] Mixed-dimension merge: 2D + 3D PDESystems merged correctly
- [x] Cross-dimension coupling equations: 3D variable at z=0 coupled to 2D equation
- [x] `slice_variable` produces correct equation
- [x] End-to-end `couple()` → `convert(PDESystem, ...)` with mixed-dimension CoupleType dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)