### PR TITLE
Fix duplicate connector equations from couple2 double-loop

### DIFF
--- a/src/coupled_system.jl
+++ b/src/coupled_system.jl
@@ -188,18 +188,22 @@ function Base.convert(::Type{<:System}, sys::CoupledSystem; name = :model, compi
     systems = copy(sys.systems)
     for (i, a) in enumerate(systems)
         for (j, b) in enumerate(systems)
-            a_t, b_t = get_coupletype(a), get_coupletype(b)
-            if hasmethod(couple2, (a_t, b_t))
-                cs = couple2(a_t(a), b_t(b))
-                @assert cs isa ConnectorSystem "The result of coupling two systems together must be a EarthSciMLBase.ConnectorSystem. " *
-                                               "This is not the case for $(nameof(a)) ($a_t) and $(nameof(b)) ($b_t); it is instead a $(typeof(cs))."
-                systems[i], a = cs.from, cs.from
-                systems[j], b = cs.to, cs.to
-                for eq in cs.eqs
-                    @assert ModelingToolkit.validate(eq) "invalid units in coupling equation: $eq. See warnings for details."
+            i >= j && continue  # Each unordered pair only once, try both directions below.
+            for (x, y, xi, yi) in ((a, b, i, j), (b, a, j, i))
+                x_t, y_t = get_coupletype(x), get_coupletype(y)
+                if hasmethod(couple2, (x_t, y_t))
+                    cs = couple2(x_t(x), y_t(y))
+                    @assert cs isa ConnectorSystem "The result of coupling two systems together must be a EarthSciMLBase.ConnectorSystem. " *
+                                                   "This is not the case for $(nameof(x)) ($x_t) and $(nameof(y)) ($y_t); it is instead a $(typeof(cs))."
+                    systems[xi] = cs.from
+                    systems[yi] = cs.to
+                    for eq in cs.eqs
+                        @assert ModelingToolkit.validate(eq) "invalid units in coupling equation: $eq. See warnings for details."
+                    end
+                    append!(connector_eqs, cs.eqs)
                 end
-                append!(connector_eqs, cs.eqs)
             end
+            a = systems[i]  # Re-sync after coupling (from/to may not match i/j order).
         end
         de = get_sys_discrete_event(a)
         (!isnothing(de)) && push!(discrete_event_fs, de)

--- a/test/coupled_system_test.jl
+++ b/test/coupled_system_test.jl
@@ -382,3 +382,42 @@ end
     @test runcount1 == 1
     @test runcount2 == 1
 end
+
+@testset "No duplicate connector equations" begin
+    struct DupACoupler
+        sys::Any
+    end
+    struct DupBCoupler
+        sys::Any
+    end
+
+    @component function DupA(; name = :DupA)
+        @variables x(t)
+        System([D_nounits(x) ~ 1], t_nounits; name, metadata = Dict(CoupleType => DupACoupler))
+    end
+
+    @component function DupB(; name = :DupB)
+        @parameters p
+        @variables y(t)
+        System([D_nounits(y) ~ p], t_nounits; name, metadata = Dict(CoupleType => DupBCoupler))
+    end
+
+    function EarthSciMLBase.couple2(a::DupACoupler, b::DupBCoupler)
+        a, b = a.sys, b.sys
+        b = EarthSciMLBase.param_to_var(b, :p)
+        ConnectorSystem([b.p ~ a.x], b, a)
+    end
+
+    cs = couple(DupA(), DupB())
+    sys = convert(System, cs; compile = false)
+
+    eq_strs = sort([string(eq) for eq in equations(sys)])
+    @test eq_strs == unique(eq_strs)
+
+    # Also verify both orderings produce no duplicates.
+    cs2 = couple(DupB(), DupA())
+    sys2 = convert(System, cs2; compile = false)
+
+    eq_strs2 = sort([string(eq) for eq in equations(sys2)])
+    @test eq_strs2 == unique(eq_strs2)
+end


### PR DESCRIPTION
## Summary

- Fix the double-nested coupling loop in `convert(System, CoupledSystem)` that produced duplicate connector equations when `ConnectorSystem`'s `from`/`to` swapped system positions
- Add `i >= j` guard so each unordered pair is visited once, with an inner loop trying both coupling directions
- Re-sync the outer loop variable after each pair to handle `from`/`to` ordering that doesn't match position order

Fixes #172

## Test plan

- [x] New regression test "No duplicate connector equations" verifies no duplicates in both system orderings
- [x] All 6 permutation tests pass (previously 3 failed with "System names must be unique" errors caused by the duplicate equations)
- [x] Full test suite passes (except pre-existing Sensitivity test failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)