### PR TITLE
Fix param_to_var + merge_pdesystems for PDE-level coupling (#190)

### DIFF
--- a/src/param_to_var.jl
+++ b/src/param_to_var.jl
@@ -110,6 +110,12 @@ function param_to_var(sys::ModelingToolkit.PDESystem, ps::Symbol...)
     # Remove converted parameters
     new_ps = [p for p in params if !(Symbolics.unwrap(p) in keys(replace))]
 
-    PDESystem(new_eqs, new_bcs, sys.domain, sys.ivs, sys.dvs, new_ps;
+    # Add promoted variables to the dependent variables list
+    new_dvs = copy(sys.dvs)
+    for newvar_unwrapped in values(replace)
+        push!(new_dvs, Symbolics.wrap(newvar_unwrapped))
+    end
+
+    PDESystem(new_eqs, new_bcs, sys.domain, sys.ivs, new_dvs, new_ps;
         name = nameof(sys), metadata = sys.metadata)
 end

--- a/src/pdesystem_coupling.jl
+++ b/src/pdesystem_coupling.jl
@@ -187,6 +187,40 @@ function merge_pdesystems(pdesystems::AbstractVector{<:ModelingToolkit.PDESystem
         end
     end
 
+    # Resolve connector equations between same-named DVs that were deduplicated.
+    # When unique_syms drops a DV (same name AND same string representation),
+    # equations referencing the dropped symbolic object become orphaned.
+    # Build a substitution map mirroring unique_syms's logic, apply it to all
+    # equations and BCs, then drop trivial equations (LHS == RHS).
+    all_dvs_raw = vcat([p.dvs for p in pdesystems]...)
+    seen_dv_syms = Dict{Symbol, String}()      # symbol → first string repr
+    surviving_dv = Dict{String, Any}()          # string repr → surviving DV
+    dv_subs = Dict{Any, Any}()
+    for dv in all_dvs_raw
+        sym = Symbol(Symbolics.tosymbol(dv, escape = false))
+        s_str = string(dv)
+        if !haskey(seen_dv_syms, sym)
+            seen_dv_syms[sym] = s_str
+            surviving_dv[s_str] = dv
+        elseif seen_dv_syms[sym] == s_str
+            # True duplicate dropped by unique_syms — map to surviving version
+            dv_subs[Symbolics.unwrap(dv)] = Symbolics.unwrap(surviving_dv[s_str])
+        end
+        # Different representation with same name: kept by unique_syms, no sub needed
+    end
+    if !isempty(dv_subs)
+        all_eqs = map(all_eqs) do eq
+            Symbolics.substitute(eq.lhs, dv_subs) ~ Symbolics.substitute(eq.rhs, dv_subs)
+        end
+        all_eqs = filter(eq -> !isequal(eq.lhs, eq.rhs), all_eqs)
+        all_eqs = unique_eqs(all_eqs)
+
+        all_bcs = map(all_bcs) do bc
+            Symbolics.substitute(bc.lhs, dv_subs) ~ Symbolics.substitute(bc.rhs, dv_subs)
+        end
+        all_bcs = unique_eqs(all_bcs)
+    end
+
     PDESystem(all_eqs, all_bcs, unified_domains, unified_ivs, all_dvs, all_ps; name = name)
 end
 

--- a/test/param_to_var_test.jl
+++ b/test/param_to_var_test.jl
@@ -89,7 +89,11 @@ end
     @test length(equations(pdesys2)) == 1
     @test length(pdesys2.bcs) == 1
     @test length(pdesys2.ivs) == 3
-    @test length(pdesys2.dvs) == 1
+    # S was promoted from parameter to DV
+    @test length(pdesys2.dvs) == 2
+    dv_names = [Symbolics.tosymbol(dv, escape = false) for dv in pdesys2.dvs]
+    @test :S ∈ dv_names
+    @test :ψ ∈ dv_names
 end
 
 @testset "PDESystem param_to_var - skip existing variable" begin

--- a/test/pdesystem_coupling_test.jl
+++ b/test/pdesystem_coupling_test.jl
@@ -1149,3 +1149,51 @@ end
         @test count == 1
     end
 end
+
+@testset "Issue #190: param_to_var connector resolved by merge" begin
+    # When param_to_var promotes a parameter to a DV with the same name as a DV
+    # in another system, the connector equation linking them should be resolved
+    # by merge_pdesystems (substituted to trivial, then removed).
+    # This is the pattern that WildlandFire.jl uses for FireSpreadDirection→LevelSet.
+
+    @parameters x_190 y_190
+    @variables u_190(..) [description = "PDE state"]
+    @parameters R_190 = 1.0 [description = "Rate parameter"]
+    Dx_190 = Differential(x_190)
+
+    # PDE system with parameter R_190
+    pde_190 = PDESystem(
+        [D_test(u_190(t_test, x_190, y_190)) ~ -R_190 * u_190(t_test, x_190, y_190)],
+        [u_190(0, x_190, y_190) ~ 1.0],
+        [t_test ∈ Interval(0.0, 1.0),
+         x_190 ∈ Interval(0.0, 1.0), y_190 ∈ Interval(0.0, 1.0)],
+        [t_test, x_190, y_190], [u_190(t_test, x_190, y_190)], [R_190];
+        name = :pde_190
+    )
+
+    # Another PDE system that defines R_190 as a DV (simulates promoted ODE group)
+    @variables R_190_src(..) [description = "Rate from ODE"]
+    @parameters k_190 = 2.0
+    pde_src = PDESystem(
+        [R_190_src(t_test, x_190, y_190) ~ k_190],
+        [R_190_src(0, x_190, y_190) ~ 2.0],
+        [t_test ∈ Interval(0.0, 1.0),
+         x_190 ∈ Interval(0.0, 1.0), y_190 ∈ Interval(0.0, 1.0)],
+        [t_test, x_190, y_190], [R_190_src(t_test, x_190, y_190)], [k_190];
+        name = :src_190
+    )
+
+    # Use param_to_var to convert R_190 to a variable, then create a connector
+    pde_190_mod = param_to_var(pde_190, :R_190)
+    @test length(pde_190_mod.dvs) == 2  # u_190 + R_190
+
+    # The connector links R_190 (now a DV in pde_190) to R_190_src
+    eq_vars = Symbolics.get_variables(equations(pde_190_mod)[1])
+    R_sym = only(filter(v -> Symbolics.tosymbol(v, escape = false) == :R_190, eq_vars))
+    connector = [R_sym ~ R_190_src(t_test, x_190, y_190)]
+
+    merged = merge_pdesystems([pde_src, pde_190_mod], connector)
+
+    # Key assertion: equation count must equal DV count
+    @test length(equations(merged)) == length(merged.dvs)
+end


### PR DESCRIPTION
## Summary

- `param_to_var` for PDESystem now adds promoted variables to the DVs list. Previously, converted parameters appeared in equations but were missing from DVs.
- `merge_pdesystems` now resolves connector equations between same-named DVs from different systems. After `unique_syms` deduplicates DVs, a substitution maps dropped DV variants to surviving ones. Trivial connector equations (LHS == RHS) are removed, keeping the equation/DV count balanced.

Fixes #190.

## Test plan

- [x] Updated `param_to_var` PDESystem test to expect promoted variable in DVs
- [x] Added `Issue #190` test verifying equation count == DV count after merge with `param_to_var` connectors
- [ ] Existing tests pass
- [ ] WildlandFire.jl `@test_broken` in PR #54 should start passing once this is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)