### PR TITLE
Truncate staggering vector in grid() when it exceeds spatial dimensions

### DIFF
--- a/src/domaininfo.jl
+++ b/src/domaininfo.jl
@@ -177,7 +177,11 @@ function grid(d::DomainInfo{T}) where {T}
 end
 function grid(d::DomainInfo{T}, staggering) where {T}
     endpts = endpoints(d)
-    @assert length(staggering)==length(endpts) "The number of staggering values $(length(staggering)) must match the number of partial independent variables $(length(endpts))."
+    ndims = length(endpts)
+    if length(staggering) > ndims
+        staggering = staggering[1:ndims]
+    end
+    @assert length(staggering)==ndims "The number of staggering values $(length(staggering)) must match the number of partial independent variables $(ndims)."
     @assert all(isa.(staggering, (Bool,))) "Staggering must be a vector of booleans."
     [stag ? range(start = s - d / 2, step = d, length = length(s:d:e) + 1) : s:d:e
      for (stag, (s, e), d) in zip(staggering, endpts, d.grid_spacing)]

--- a/test/domaininfo_test.jl
+++ b/test/domaininfo_test.jl
@@ -165,6 +165,15 @@ end
     @test length(di.partial_derivative_funcs) == 0
 end
 
+@testset "grid staggering truncation" begin
+    di = DomainInfo(DateTime(2024, 1, 1), DateTime(2024, 1, 1, 3);
+        xrange = 0:0.1:1, yrange = 0:0.1:2)
+
+    # staggering with more elements than spatial dims should be truncated
+    @test grid(di, (true, false, false)) ≈ [-0.05:0.1:1.05, 0.0:0.1:2.0]
+    @test grid(di, (false, true, true)) ≈ [0.0:0.1:1.0, -0.05:0.1:2.05]
+end
+
 @testset "t_ref" begin
     s, e = DateTime(2024, 1, 1), DateTime(2024, 1, 1, 3)
     di = DomainInfo(s, e; xrange = 0:0.1:1, yrange = 0:0.1:2)


### PR DESCRIPTION
## Summary
- Fixes `grid(di::DomainInfo, staggering)` failing when `staggering` has more elements than the number of spatial dimensions in `DomainInfo`
- This occurs when EarthSciData hardcodes 3D staggering (e.g., `(false, false, false)`) but the domain is 2D
- The fix truncates the `staggering` vector to match the number of spatial dimensions, while still asserting if too few values are provided

## Test plan
- [x] Added test for 2D domain with 3-element staggering vector `(true, false, false)`
- [x] Added test for 2D domain with 3-element staggering vector `(false, true, true)`
- [ ] Existing tests continue to pass (CI)

Fixes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)