### PR TITLE
Substitute coord placeholders into observed equations

### DIFF
--- a/src/mtk_grid_func.jl
+++ b/src/mtk_grid_func.jl
@@ -96,6 +96,22 @@ function gen_coord_func(sys, expr, coord_args, alg::MapAlgorithm = MapBroadcast(
         eval_expression = false, eval_module = @__MODULE__)
     placeholders, subst = _coord_placeholders(sys, coord_args)
     expr_sub = isempty(subst) ? expr : Symbolics.substitute.(expr, (subst,))
+
+    # `build_function_wrapper` inlines observed equations into `expr_sub` via the
+    # system's stored observed RHSs. Those RHSs were not touched by the substitution
+    # above (only `expr` was), so any `_CoordTmpF(coord, i)(t)` calls hidden inside
+    # `observed(sys)` would land in the generated code unsubstituted and fall through
+    # to the `(::_CoordTmpF)(t) = Inf` fallback at runtime. Pre-inline observed (with
+    # placeholder-substituted RHSs) into `expr_sub` so the downstream `obs_subber` is
+    # a no-op; `Symbolics.fixpoint_sub` resolves nested observed references.
+    if !isempty(subst) && !isempty(ModelingToolkit.observed(sys))
+        obs_subst = Dict{Any, Any}()
+        for eq in ModelingToolkit.observed(sys)
+            obs_subst[eq.lhs] = Symbolics.substitute(eq.rhs, subst)
+        end
+        expr_sub = Symbolics.fixpoint_sub.(expr_sub, (obs_subst,))
+    end
+
     args, p_start, p_end = _coord_function_args(sys, placeholders)
 
     fexpr = ModelingToolkit.build_function_wrapper(

--- a/test/mtk_grid_func_test.jl
+++ b/test/mtk_grid_func_test.jl
@@ -114,6 +114,38 @@ end
     @test [14] ≈ obs_f(u0, p, 0.0, 1, 2, 3)
 end
 
+# Regression: the equation RHS may reference an observed variable whose RHS
+# (not the equation RHS) is the one that depends on coords. `gen_coord_func`
+# applies the placeholder substitution to equation RHSs only, so without
+# pre-inlining observed before `build_function_wrapper`, the unsubstituted
+# `_CoordTmpF()(t)` calls inside observed RHSs end up in the generated code
+# via `obs_subber` and silently evaluate to `Inf` at runtime.
+@testset "coord-dependent observed used by equation RHS" begin
+    @parameters lon2=0.0 lat2=0.0 lev2=1.0
+    @variables u2(t)=1.0 coord_term(t)
+    eqs2 = [
+        coord_term ~ 2 * lon2 + 3 * lat2 + lev2,  # observed (the only coord refs)
+        D(u2) ~ coord_term + 1                    # eq RHS only refs the observed
+    ]
+    indepdomain2 = t ∈ Interval(0.0, 1.0)
+    partialdomains2 = [
+        lon2 ∈ Interval(-π, π),
+        lat2 ∈ Interval(-0.45π, 0.45π),
+        lev2 ∈ Interval(1, 3)
+    ]
+    domain2 = DomainInfo(
+        partialderivatives_δxyδlonlat,
+        constIC(0.0, indepdomain2), constBC(0.0, partialdomains2...);
+        grid_spacing = [1.0, 1.0, 1.0]
+    )
+    sys2 = mtkcompile(System(eqs2, t, name = :sys2))
+    sys_coord2, coord_args2 = EarthSciMLBase._prepare_coord_sys(sys2, domain2)
+    f2 = EarthSciMLBase.build_coord_ode_function(sys_coord2, coord_args2)
+    p2 = MTKParameters(sys_coord2, ModelingToolkit.initial_conditions(sys_coord2))
+    # At lon=5, lat=2, lev=4: coord_term = 2*5 + 3*2 + 4 = 20, so D(u2) = 21.
+    @test f2([1.0], p2, 0.0, 5.0, 2.0, 4.0) ≈ [21.0]
+end
+
 if Sys.isapple()
     @testset "GPU jacobian" begin
         using Metal


### PR DESCRIPTION
## Summary

PR #210 fixed the post-codegen textual rewrite of coord arguments by
substituting `_CoordTmpF(coord, i)(t)` calls with placeholder symbolic
parameters before code generation, but only applied the substitution to
equation RHSs. `build_function_wrapper` then inlines observed equations
via `obs_subber` (using the system's *unsubstituted* observed RHSs), so
any `_CoordTmpF()(t)` call that lives inside an observed RHS — and whose
referencing equation RHS is just an obs-var lookup — lands in the generated
code unsubstituted and falls through to `(::_CoordTmpF)(t) = Inf` at runtime.

The fallback is particularly easy to miss because the most common emission
pattern is `ifelse(lev < 2, BIG_EXPR, zero_emis)`: with `lev` ending up in
an observed expression, the inlined `_CoordTmpF()(t)` returns `Inf`, the
comparison evaluates `Inf < 2 = false`, and the `ifelse` silently returns
`zero_emis = 0` for every grid cell. Strang/IMEX solves of EarthSciData's
NEI emissions tests therefore produced `sum(sol.u[end]) = 0.0` instead of
the expected `~2e-5`, with `retcode = Success`.

Fix: in `gen_coord_func`, after substituting placeholders into the equation
RHSs, also walk `observed(sys)`, substitute placeholders into each observed
RHS, and pre-inline the substituted observed into `expr_sub` via
`Symbolics.fixpoint_sub` (which handles nested observed references). The
downstream `obs_subber` is then a no-op because `expr_sub` no longer
references any observed lhs.

## Diagnostic confirming the bug

A minimal probe of the `gen_coord_func` input for the NEI test in
EarthSciData reports:

```
EQ 1 lhs: Differential(t, 1)(sys₊ACET(t))
EQ 1 rhs: sys₊NEI2016MonthlyEmis_ACET(t)
total CoordTmpF in eq RHSs: 0
total CoordTmpF in obs RHSs: 354 across 70 obs eqs
```

i.e. the equation RHS is just an observed-variable reference, and all 354
`_CoordTmpF` calls live in the 70 observed RHSs that PR #210's substitution
left untouched.

## Verification

`EarthSciData.jl` `solve_test.jl::Strang Serial` with the patched package
returns `sum(sol.u[end]) = 2.0143813227072414e-5` (expected ≈ `2.014381322963178e-5`,
matches within `rtol = 0.01`). The same test was producing `0.0` on
EarthSciMLBase v0.25.7 main.

## Test plan

- [x] New regression test in `test/mtk_grid_func_test.jl` covering the
  eq-RHS-references-observed pattern that PR #210 missed
- [x] Verified end-to-end on `EarthSciData.jl` PR #201 `solve_test.jl::Strang Serial`
- [ ] CI: re-run full `EarthSciMLBase.jl` test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)