### PR TITLE
Strang solver strips build-only kwargs from the inner stiff solver

### DIFF
--- a/src/solver_strategy_strang.jl
+++ b/src/solver_strategy_strang.jl
@@ -174,7 +174,11 @@ function _strang_integrators(
     # so its `initialize = affect` populates parameter buffers before `init`'s
     # auto_dt_reset! evaluates the RHS — otherwise NaN propagates from
     # still-empty interpolator buffers (issue #219).
-    nt = (; st.stiff_kwargs...)
+    # `sparse` is consumed separately for the Jacobian build (see `:sparse in keys(...)`
+    # below) and `optimize` is not a solver/init keyword at all — both are build-only.
+    # Strip them from the kwargs forwarded to the inner stiff ODEProblem/solver so
+    # OrdinaryDiffEq's strict keyword check does not reject them.
+    nt = Base.structdiff((; st.stiff_kwargs...), NamedTuple{(:sparse, :optimize)})
     inner_kwargs = if isnothing(event_cb)
         nt
     else

--- a/test/solver_strategy_test.jl
+++ b/test/solver_strategy_test.jl
@@ -446,3 +446,29 @@ end
         @test cc.runcount > 0
     end
 end
+
+@testset "Strang stiff_kwargs strip build-only kwargs" begin
+    # Regression test for build-only kwargs: `sparse` is consumed separately
+    # for the Jacobian build in `ODEProblem(::CoupledSystem, ::SolverStrang)`
+    # and `optimize` is not a solver/init keyword at all. Forwarding either to
+    # the inner stiff sub-integrators makes OrdinaryDiffEq's strict keyword
+    # check throw ("Unrecognized keyword arguments"), so `_strang_integrators`
+    # must strip them while still honoring genuine solver kwargs like `reltol`.
+    st_kw = SolverStrangSerial(Tsit5(), 1.0; sparse = true, optimize = false,
+        reltol = 1e-2)
+    tstart = EarthSciMLBase.get_tspan(domain)[1]
+
+    # Building the sub-integrators calls `init`, which errors if the
+    # build-only kwargs are forwarded (i.e. if the strip is reverted).
+    _, integrators_kw = EarthSciMLBase._strang_integrators(
+        st_kw, domain, f_ode, u0_single, tstart, p, nothing)
+    @test length(integrators_kw) == 1
+    # Genuine solver kwargs must still reach the inner integrators.
+    @test integrators_kw[1].opts.reltol == 1e-2
+
+    # Public API: coupled-problem construction reaches `_strang_integrators`
+    # (and consumes `sparse = true` for the Jacobian build), so it must
+    # succeed with build-only kwargs present.
+    prob_kw = ODEProblem(csys, st_kw)
+    @test prob_kw isa ODEProblem
+end


### PR DESCRIPTION

**bugfix · non-breaking**

## Motivation
`SolverStrangThreads`/`SolverStrangSerial` accept `sparse`/`optimize` to configure the per-cell **ODEFunction build** (sparse Jacobian, symbolic optimization passes). The Strang builder itself already treats `:sparse` as a build option read out-of-band from `stiff_kwargs` — `ODEProblem(::CoupledSystem, ::SolverStrang)` does `sparse = :sparse in keys(st.stiff_kwargs) ? st.stiff_kwargs[:sparse] : false` (`solver_strategy_strang.jl`) and passes it to the Jacobian build. So `stiff_kwargs` is the *only* channel for requesting a sparse per-cell Jacobian under Strang. But the same NamedTuple is then forwarded verbatim to the inner `ODEProblem`/`init`, whose strict keyword check rejects it with an "unrecognized keyword arguments" error — and since the inner `init` runs inside `ODEProblem(::CoupledSystem, ::SolverStrang)`, the throw happens during the coupled-problem build. The `sparse` option is therefore unusable as shipped — any driver that sets it (e.g. a GEOS-Chem CTM passing `sparse=true` for a KLU Jacobian) crashes before the first step. `optimize` is not referenced anywhere in the package and is not a `solve`/`init` keyword, so forwarding it can only ever error.

## Change
Keep `sparse`/`optimize` visible to the builder but `Base.structdiff` them out of the kwargs forwarded to the inner stiff integrator, at the single forwarding site in `_strang_integrators`. Stripping at the forwarding site (rather than filtering in the `SolverStrang*` constructors) leaves the public API and the builder's out-of-band `:sparse` read untouched.

## Why this departs from the current design
The `stiff_kwargs` docstring ("Keyword arguments for the stiff ODEProblem constructor and solver") implies forward-everything; this PR narrows that to forward-everything-except-build-options. No working caller can be affected: because the inner `init` rejects these two keywords unconditionally, every call whose forwarded kwargs change under this PR previously threw. Behavior only differs for callers that previously hit the error.

## Validation
- New behavioral test (`solver_strategy_test.jl`): builds the sub-integrators through the real path — `EarthSciMLBase._strang_integrators` with a strategy carrying `sparse = true, optimize = false, reltol = 1e-2` (construction calls the inner `init`, which throws "Unrecognized keyword arguments" if the strip is reverted), asserts the genuine solver kwarg (`reltol`) still reaches the inner integrator, and constructs `ODEProblem(csys, st)` end-to-end with `sparse = true` so the builder's out-of-band `:sparse` consumption (sparse per-cell Jacobian build) is exercised in the same test.
- Full-suite `Pkg.test` on this branch vs an upstream/main baseline: failure set identical to the baseline (the two `mtk_grid_func` grid-solve tests upstream marked broken on Julia 1.12.5+), with the new testset green (Solver Strategies 48 pass / 0 fail).
- Author-side integration evidence (not reproducible from this repo): a 274-species GEOS-Chem CTM (KLU sparse Jacobian) builds and solves without error end-to-end with this change.

## Notes
No API change.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
