### PR TITLE
gen_coord_func: codegen-first coordinate handling (fixes large-mechanism jac StackOverflow)

### DIFF
--- a/src/mtk_grid_func.jl
+++ b/src/mtk_grid_func.jl
@@ -23,67 +23,59 @@ function rewrite_broadcast(x)
     return x
 end
 
-# Placeholder symbolic variable carrying a coordinate's name + unit.  Used as
-# a trailing function argument so `build_function_wrapper` generates code that
-# references the coordinate by name rather than via the parameter buffer.
-function _coord_placeholder(name::Symbol, unit)
-    sym = Symbolics.unwrap(Symbolics.variable(name; T = Real))
-    sym = ModelingToolkit.toparam(sym)
-    if unit !== nothing
-        sym = Symbolics.setmetadata(sym, ModelingToolkit.VariableUnit, unit)
+# Move coordinate references from the generated code's body to the argument list.
+# Rewrites the generated function's AST *after* codegen: (1) appends the
+# coordinate argument symbols to the signature; (2) replaces every literal
+# `_CoordTmpF` call site with the matching coordinate argument. Operating
+# post-codegen (rather than substituting the symbolic expressions before codegen)
+# preserves the `===` node sharing that the SymbolicUtils fast_toexpr backend
+# relies on for deduplication, which keeps the generated body from blowing up on
+# large mechanisms (large sparse Jacobians).
+function rewrite_coord_func(x, coord_args, idv::Symbol)
+    if @capture(x, function (args__)
+        body_
+    end)
+        return :(function ($(args...), $(coord_args...))
+            $body
+        end)
+    elseif @capture(x, (a_)(b_))
+        # Under the fast_toexpr backend the independent variable may be renamed to
+        # a hashed argument symbol (`__argₛᵧₘ<hash>`), so we do NOT require
+        # `b == idv` — a literal `_CoordTmpF` instance in call position is
+        # unambiguous by itself.
+        if a isa _CoordTmpF
+            return :($(coord_args[a.idx]))
+        end
     end
-    return sym
+    return x
 end
 
-# Recursively walk a symbolic expression and apply `f!` to every subexpression
-# whose top-level `operation` is a `_CoordTmpF`.
-function _foreach_coord_tmp(f!, expr)
-    expr = Symbolics.unwrap(expr)
-    if Symbolics.iscall(expr)
-        if Symbolics.operation(expr) isa _CoordTmpF
-            f!(expr)
-        end
-        for a in Symbolics.arguments(expr)
-            _foreach_coord_tmp(f!, a)
-        end
+# Loud build-time guard: a `_CoordTmpF` left in the generated code would silently
+# evaluate to `Inf` at runtime (the `(::_CoordTmpF)(t) = Inf` fallback below). If
+# the codegen backend ever changes shape such that the postwalk pattern above no
+# longer matches, fail the build instead.
+function _assert_no_coord_tmp(ex)
+    ok = Ref(true)
+    MacroTools.postwalk(ex) do x
+        x isa _CoordTmpF && (ok[] = false)
+        x
     end
-    return nothing
+    ok[] || error(
+        "gen_coord_func: an unrewritten _CoordTmpF coordinate placeholder remains in " *
+        "the generated code — the post-codegen AST rewrite pattern no longer matches " *
+        "this codegen backend. Coordinates would evaluate to Inf at runtime.")
+    return ex
 end
 
-# Walk `sys_coord` equations + observed to collect every `_CoordTmpF(coord, i)(t)`
-# term that `_prepare_coord_sys` inserted.  Returns a Vector indexed by `i`; any
-# coordinate not referenced in the system gets a placeholder with no unit.
-function _coord_placeholders(sys_coord, coord_args)
-    found = Dict{Int, Tuple{Any, Any}}() # idx => (tmp_term, coord)
-    sources = vcat(equations(sys_coord), ModelingToolkit.observed(sys_coord))
-    for eq in sources, side in (eq.lhs, eq.rhs)
-
-        _foreach_coord_tmp(side) do term
-            op = Symbolics.operation(term)
-            get!(found, op.idx, (term, op.coord))
-        end
-    end
-    phs = Vector{Any}(undef, length(coord_args))
-    subst = Dict()
-    for i in eachindex(coord_args)
-        unit_c = haskey(found, i) ? ModelingToolkit.get_unit(found[i][2]) : nothing
-        phs[i] = _coord_placeholder(coord_args[i], unit_c)
-        if haskey(found, i)
-            subst[found[i][1]] = phs[i]
-        end
-    end
-    return phs, subst
+function _add_coord_args(ex, coord_args, idv::Symbol, ::MapAlgorithm)
+    ex = MacroTools.postwalk(x -> rewrite_coord_func(x, coord_args, idv), ex)
+    _assert_no_coord_tmp(ex)
 end
 
-# Build the function signature arguments that `build_function_wrapper` expects
-# for a coord-aware generated function.  Returns `(args..., p_start, p_end)`.
-function _coord_function_args(sys, placeholders)
-    dvs = unknowns(sys)
-    ps = parameters(sys; initial_parameters = true)
-    p = tuple(ModelingToolkit.reorder_parameters(sys, Symbolics.unwrap.(ps))...)
-    iv = ModelingToolkit.get_iv(sys)
-    args = (dvs, p..., iv, placeholders...)
-    return args, 2, 1 + length(p)
+function _add_coord_args(ex, coord_args, idv::Symbol, ::MapReactant)
+    ex = MacroTools.postwalk(x -> rewrite_coord_func(x, coord_args, idv), ex)
+    _assert_no_coord_tmp(ex)
+    ex = MacroTools.postwalk(x -> rewrite_broadcast(x), ex)
 end
 
 """
@@ -94,41 +86,14 @@ downstream grid-evaluation machinery.
 """
 function gen_coord_func(sys, expr, coord_args, alg::MapAlgorithm = MapBroadcast();
         eval_expression = false, eval_module = @__MODULE__)
-    placeholders, subst = _coord_placeholders(sys, coord_args)
-    expr_sub = isempty(subst) ? expr : Symbolics.substitute.(expr, (subst,))
-
-    # `build_function_wrapper` inlines observed equations into `expr_sub` via the
-    # system's stored observed RHSs. Those RHSs were not touched by the substitution
-    # above (only `expr` was), so any `_CoordTmpF(coord, i)(t)` calls hidden inside
-    # `observed(sys)` would land in the generated code unsubstituted and fall through
-    # to the `(::_CoordTmpF)(t) = Inf` fallback at runtime. Pre-inline observed (with
-    # placeholder-substituted RHSs) into `expr_sub` so the downstream `obs_subber` is
-    # a no-op; `Symbolics.fixpoint_sub` resolves nested observed references.
-    if !isempty(subst) && !isempty(ModelingToolkit.observed(sys))
-        obs_subst = Dict{Any, Any}()
-        for eq in ModelingToolkit.observed(sys)
-            obs_subst[eq.lhs] = Symbolics.substitute(eq.rhs, subst)
-        end
-        expr_sub = Symbolics.fixpoint_sub.(expr_sub, (obs_subst,))
-    end
-
-    args, p_start, p_end = _coord_function_args(sys, placeholders)
-
-    fexpr = ModelingToolkit.build_function_wrapper(
-        sys, expr_sub, args...;
-        p_start = p_start, p_end = p_end, expression = Val{true}
-    )
-
-    if alg isa MapReactant
-        fexpr = fexpr isa Tuple ?
-                map(f -> MacroTools.postwalk(rewrite_broadcast, f), fexpr) :
-                MacroTools.postwalk(rewrite_broadcast, fexpr)
-    end
-
+    idv = var2symbol(ModelingToolkit.get_iv(sys))
+    fexpr = ModelingToolkit.generate_custom_function(sys, expr, expression = Val{true})
     if fexpr isa Tuple
+        fexpr = _add_coord_args.(fexpr, (coord_args,), (idv,), (alg,))
         f = ModelingToolkit.eval_or_rgf.(fexpr; eval_expression, eval_module)
         return ModelingToolkit.GeneratedFunctionWrapper{(2, 6, true)}(f[1], f[2])
     else
+        fexpr = _add_coord_args(fexpr, coord_args, idv, alg)
         return ModelingToolkit.eval_or_rgf(fexpr; eval_expression, eval_module)
     end
 end

--- a/test/mtk_grid_func_test.jl
+++ b/test/mtk_grid_func_test.jl
@@ -184,3 +184,15 @@ end
         @test_broken err === nothing
     end
 end
+
+
+@testset "gen_coord_func loud guard on unrewritten coordinate placeholders" begin
+    # A _CoordTmpF left in generated code silently evaluates to Inf at runtime;
+    # the build-time guard must fail loudly instead when the post-codegen AST
+    # rewrite pattern stops matching.
+    tmp = EarthSciMLBase._CoordTmpF(nothing, 1)
+    bad = Expr(:call, tmp, :t)
+    clean = :(f(x) + g(y))
+    @test EarthSciMLBase._assert_no_coord_tmp(clean) === clean
+    @test_throws ErrorException EarthSciMLBase._assert_no_coord_tmp(bad)
+end


### PR DESCRIPTION

**bugfix · non-breaking (internal-helper removal noted)**

## Motivation
For large mechanisms the per-cell Jacobian generated function grew to ~1e5–1e6 statements and overflowed the task stack on first-call compilation (`StackOverflowError` inside `jac_stiff` → `calc_J!` under TRBDF2). A 274-species GEOS-Chem CTM could not build; a 19-species SuperFast stayed just under the threshold.

## Root cause
`gen_coord_func` rewrote every symbolic expression **before** codegen (`Symbolics.substitute` over each sparse-Jacobian entry + `fixpoint_sub` pre-inlining of all observed equations). That rebuild destroys the `===` node sharing the MTKBase/SymbolicUtils `fast_toexpr` backend relies on for deduplication (identity-keyed IR population), exploding the generated body.

## Change
Restore the codegen-first scheme: `generate_custom_function` first, then a size-preserving `MacroTools.postwalk` that appends the coordinate arguments and rewrites `_CoordTmpF` call sites. Adds `_assert_no_coord_tmp` — a loud build-time failure if a placeholder instance is left unrewritten in the generated AST (it would otherwise silently evaluate to `Inf` at runtime). Removes the now-dead pre-codegen helpers (`_coord_placeholder`, `_foreach_coord_tmp`, `_coord_placeholders`, `_coord_function_args`).

## Why this departs from the current design
This deliberately reverses the pre-codegen substitution scheme introduced in 7f473fb2 ("Fix coord argument codegen for MTK v11 CSE output") and extended in 5d94ee11 ("Substitute coord placeholders into observed equations"), so it should answer the reasons those commits gave for abandoning the AST rewrite:

- **Why reverse at all:** the symbolic-level fix is correct but not size-preserving. `Symbolics.substitute` over every sparse-Jacobian entry plus `fixpoint_sub` pre-inlining of *all* observed equations rebuilds every expression tree, which destroys the `===` node sharing the fast_toexpr backend keys its deduplication on. For small systems that is invisible; for the 274-species mechanism it is the difference between a compilable function and a ~1e5–1e6-statement body that overflows the task stack on first call. Under the current design, large mechanisms cannot build at all — there is no workaround short of not using coord-aware codegen.
- **Why not make the pre-codegen substitution sharing-preserving instead:** there is no sharing-preserving substitution API to reach for — `Symbolics.substitute` / `fixpoint_sub` rebuild each expression tree node-by-node, and preserving `===` identity across a rewrite would require hash-consing the whole pass, which SymbolicUtils does not provide. Post-codegen AST rewriting sidesteps the problem structurally: the generated code is already deduplicated when the (size-preserving) `postwalk` touches it.
- **The silent-failure mode that motivated 7f473fb2**: that commit records *two* reasons the old `(a_)(b_)` pattern stopped matching MTK v11/Symbolics v7 output — the CSE'd call argument was no longer the literal `:t` (the pattern required `b == :t`), and the placeholder operation was emitted as a constructor-call `Expr` rather than a literal `_CoordTmpF` instance — so coords fell through to the `Inf` fallback with no build-time error. Both shapes are accounted for. The restored pattern drops the argument constraint entirely, so CSE'd/renamed argument symbols (`__argₛᵧₘ<hash>`) match. And the current MTKBase-1.42 `fast_toexpr` backend embeds the placeholder as a literal instance in call position — verified empirically, not assumed: the suite's coord-codegen value assertions (`mtk_grid_func_test.jl` top level — `du`, sparse/dense Jacobian, tgrad, observed, all compared against non-coord references) pass on this branch under a fresh registry resolve, and would return `Inf` if the pattern missed. For the *future*, `_assert_no_coord_tmp` fails the build if a placeholder instance is left anywhere in the generated AST — a guard the original codegen-first scheme never had, and the reason its regression went unnoticed. A backend change that re-serializes the placeholder as a constructor call (the 7f473fb2 shape) would evade that leaf check, but is caught loudly by the same in-suite value assertions, which cannot pass on `Inf`.
- **The observed-equations hole that motivated 5d94ee11** (placeholders hidden inside `observed(sys)` RHSs escaping the equation-only substitution): closed structurally rather than by a second substitution pass. The postwalk runs on the fully generated code, *after* `generate_custom_function` has inlined observed equations, so placeholders are rewritten wherever they surface. The regression test added in 5d94ee11 (eq-RHS-references-observed) passes unchanged on this branch.
- **Helper removal:** the four removed functions are underscore-private internals that exist only to serve the pre-codegen scheme; nothing else in `src`, `test`, or `docs` references them.

## Validation
- New test (`mtk_grid_func_test.jl`): `_assert_no_coord_tmp` passes clean AST, throws on a literal `_CoordTmpF` in call position.
- Observed-equation / operator codegen behavior-preserving: full-suite `Pkg.test` on this branch has a failure set identical to the upstream/main baseline — the only failures are the two `mtk_grid_func` grid-solve tests upstream already marked broken on Julia 1.12.5+ (366efba6), which this PR does not touch. All pre-codegen-era regression tests (including 5d94ee11's observed-substitution test) pass.
- 274-species (273 solved states) GEOS-Chem tiny-domain build+solve: succeeds (was StackOverflow). Author-side integration evidence (not reproducible from this repo): in larger-domain coupled runs the rewrite changed only build scalability, not solver results; the reproducible evidence for this PR is the in-repo tiny-domain build+solve test and the full-suite baseline comparison above.

## Notes
Internal helpers were removed — anyone pinning those private symbols should update.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
