### PR TITLE
`callback_vars` protocol + 2-arg discrete-event factory forwarding

### DIFF
--- a/docs/src/operator.md
+++ b/docs/src/operator.md
@@ -188,3 +188,38 @@ anim = @animate for i in 1:length(sol.u)
 end
 gif(anim, fps = 15)
 ```
+
+## Advertising met dependencies from operators and callbacks
+
+`EarthSciData` prunes interpolators that appear in no compiled equation. A met field that a
+component consumes **out of band** — read only inside an `Operator` or an init-callback's
+observed function, not through a system equation — is invisible to that prune and would be
+dropped, leaving a zero-sentinel buffer. (A callback whose sole-consumer variable is pruned
+this way is silently disabled with no error — for instance a boundary-layer mixing callback
+that reads a PBL-height field.)
+
+To keep such fields live, a component declares what it needs:
+
+```julia
+# for an operator:
+EarthSciMLBase.get_needed_vars(op::MyOperator, csys, mtk_sys, domain::DomainInfo) = [op.pblh_var]
+
+# for an init-callback object:
+EarthSciMLBase.get_needed_vars(cb::MyCallback, csys, mtk_sys, domain::DomainInfo) = [cb.pblh_var]
+```
+
+At `convert(System, ::CoupledSystem)`, `operator_vars` and `callback_vars` gather these into
+an `extra_needed` keep-set and forward it to any discrete-event factory with a two-argument
+method:
+
+```julia
+# a prune/discrete-event factory opts in by accepting extra_needed:
+make_factory(...) = function (parent_sys, extra_needed = nothing)
+    extra_needed === nothing && return nothing   # legacy 1-arg caller: do not prune
+    apply_using(parent_sys, extra_needed)        # keep the advertised fields live
+end
+```
+
+A callback without a `get_needed_vars` method is skipped; a factory that takes only
+`parent_sys` is called unchanged (and, for a prune factory, must default to *not* pruning,
+since without the keep-set it cannot prune safely).

--- a/src/coupled_system.jl
+++ b/src/coupled_system.jl
@@ -305,7 +305,17 @@ function Base.convert(::Type{<:System}, sys::CoupledSystem; name = :model, compi
             kwargs...)
         temp_sys = mtkcompile(ModelingToolkit.flatten(compose(
             temp_connectors, systems...)))
-        de = filter(!isnothing, [f(temp_sys) for f in discrete_event_fs])
+        # Forward the operator- and callback-needed vars to any discrete-event
+        # factory that accepts them (e.g. EarthSciData's interp live-mask prune),
+        # so met fields consumed only out-of-band by operators/callbacks
+        # (callback-advertised met variables) are kept live rather than pruned. Factories
+        # that take only `parent_sys` (legacy 1-arg) are called unchanged.
+        extra_needed = isnothing(sys.domaininfo) ? Any[] :
+                       unique(vcat(operator_vars(sys, temp_sys, sys.domaininfo),
+                                   callback_vars(sys, temp_sys, sys.domaininfo)))
+        de = filter(!isnothing, [
+            applicable(f, temp_sys, extra_needed) ? f(temp_sys, extra_needed) : f(temp_sys)
+            for f in discrete_event_fs])
 
         # Create system of connectors and events.
         connectors = System(connector_eqs, iv; name = name,
@@ -870,6 +880,25 @@ end
 
 function operator_vars(sys::CoupledSystem, mtk_sys, domain::DomainInfo)
     unique(vcat([get_needed_vars(op, sys, mtk_sys, domain) for op in sys.ops]...))
+end
+
+"""
+Variables needed by the coupled system's init-callbacks (each one's
+`get_needed_vars`). Mirrors [`operator_vars`](@ref) over `sys.init_callbacks`.
+A callback (e.g. `PBLMixingCallback`, which needs `A1₊PBLH`) consumes met fields
+out-of-band in its observed function, so those fields appear in no compiled
+equation. Data loaders that prune interpolators by equation-reference must add
+these to the "keep" set or they will drop callback-only fields. Callbacks without
+a `get_needed_vars` method are skipped.
+"""
+function callback_vars(sys::CoupledSystem, mtk_sys, domain::DomainInfo)
+    cvs = Any[]
+    for c in sys.init_callbacks
+        sig = Tuple{typeof(c), typeof(sys), typeof(mtk_sys), typeof(domain)}
+        hasmethod(get_needed_vars, sig) &&
+            append!(cvs, get_needed_vars(c, sys, mtk_sys, domain))
+    end
+    unique(cvs)
 end
 
 """

--- a/test/coupled_system_test.jl
+++ b/test/coupled_system_test.jl
@@ -532,6 +532,25 @@ struct _MockPBLCallback end
 struct _Bare end
 EarthSciMLBase.get_needed_vars(::_MockPBLCallback, sys, mtk_sys, domain) = [:A1_PBLH_marker]
 
+# Fixtures for the convert(System, ...) integration test below: an operator and
+# an init-callback object that each advertise one needed variable.
+struct _NeedyOp <: Operator end
+function EarthSciMLBase.get_needed_vars(::_NeedyOp, csys, mtk_sys, domain::DomainInfo)
+    [:op_needed_marker]
+end
+
+struct _AdvertisingCallback end
+function EarthSciMLBase.get_needed_vars(::_AdvertisingCallback, sys, mtk_sys, domain)
+    [:cb_needed_marker]
+end
+# couple() only routes an object into CoupledSystem.init_callbacks when it has an
+# init_callback method with this signature. convert(System, ...) never calls it,
+# so the method body does not need to build a real callback.
+function EarthSciMLBase.init_callback(::_AdvertisingCallback, sys::CoupledSystem, sys_mtk,
+        coord_args, domain::DomainInfo, alg::MapAlgorithm)
+    error("init_callback is not used by convert(System, ...)")
+end
+
 @testset "callback_vars + 2-arg factory forwarding" begin
     import Dates
 
@@ -557,25 +576,81 @@ _dom = EarthSciMLBase.DomainInfo(Dates.DateTime(2016, 1, 1), Dates.DateTime(2016
     @test EarthSciMLBase.callback_vars(cs2, nothing, _dom) == [:A1_PBLH_marker]
 end
 
-@testset "factory dispatch: 2-arg receives extra_needed; 1-arg unchanged" begin
-    # Mirror the convert() call site: factories that accept (parent, extra_needed)
-    # get the forwarded set; legacy 1-arg factories are called with parent only.
-    seen = Ref{Any}(:untouched)
-    two_arg = function (parent_sys, extra_needed = nothing)
-        seen[] = extra_needed
-        return nothing
+@testset "convert(System, ...) forwards extra_needed to 2-arg factories" begin
+    # Integration test through the real forwarding at the convert() call site
+    # (not an inline re-implementation of the applicable-selector).
+    using DomainSets
+
+    @parameters a=0.0 b=0.0 lon=0.0 lat=0.0 lev=1.0
+    @variables begin
+        x(t_nounits) = 0.0
+        y(t_nounits) = 0.0
     end
-    one_arg = function (parent_sys)
-        return :legacy_ran
+
+    # A factory that opts in to the keep-set by accepting a second argument.
+    # It records what it received and returns a real discrete event.
+    received = Ref{Any}(:never_called)
+    two_arg_factory = function (parent_sys, extra_needed = nothing)
+        received[] = extra_needed
+        f2!(mod, obs, ctx, integ) = (esys₊a = 1.0,)
+        return [0.5] => (f = f2!, modified = (esys₊a = parent_sys.esys₊a,))
     end
-    extra_needed = [:A1_PBLH_marker, :op_var]
-    # the exact selector used at coupled_system.jl:317
-    r2 = applicable(two_arg, nothing, extra_needed) ?
-         two_arg(nothing, extra_needed) : two_arg(nothing)
-    r1 = applicable(one_arg, nothing, extra_needed) ?
-         one_arg(nothing, extra_needed) : one_arg(nothing)
-    @test seen[] == extra_needed        # 2-arg factory received the keep-set
-    @test r1 == :legacy_ran             # 1-arg factory called via the fallback branch
+    # A legacy factory with only a 1-arg method: must keep working unchanged.
+    legacy_calls = Ref(0)
+    one_arg_factory = function (parent_sys)
+        legacy_calls[] += 1
+        f1!(mod, obs, ctx, integ) = (lsys₊b = 1.0,)
+        return [0.75] => (f = f1!, modified = (lsys₊b = parent_sys.lsys₊b,))
+    end
+
+    # The (negligible) coordinate-parameter term keeps lon/lat/lev in the
+    # composed system, which convert(System, ...) requires when a DomainInfo
+    # is present (same pattern as solver_strategy_test.jl).
+    esys = System([D_nounits(x) ~ a + (lon + lat + lev) * 1.0e-16], t_nounits,
+        [x], [a, lon, lat, lev]; name = :esys,
+        metadata = Dict(SysDiscreteEvent => two_arg_factory))
+    lsys = System([D_nounits(y) ~ b], t_nounits, [y], [b]; name = :lsys,
+        metadata = Dict(SysDiscreteEvent => one_arg_factory))
+
+    dom = DomainInfo(
+        constIC(0.0, t_nounits ∈ Interval(0.0, 1.0)),
+        constBC(0.0,
+            lon ∈ Interval(-1.0, 1.0),
+            lat ∈ Interval(-1.0, 1.0),
+            lev ∈ Interval(1.0, 3.0)))
+
+    csys = couple(esys, lsys, _NeedyOp(), _AdvertisingCallback(), dom)
+    sys = convert(System, csys)
+
+    # (a) The 2-arg factory was called through its 2-arg method, (b) with the
+    # operator_vars ∪ callback_vars keep-set (operator vars first, matching the
+    # unique(vcat(...)) at the convert() call site).
+    @test received[] == [:op_needed_marker, :cb_needed_marker]
+    # (c) The legacy 1-arg factory was still called, exactly once, unchanged.
+    @test legacy_calls[] == 1
+    # Both factories' events made it into the converted system.
+    @test length(ModelingToolkit.get_discrete_events(sys)) == 2
+end
+
+@testset "convert(System, ...) without DomainInfo forwards an empty keep-set" begin
+    @parameters c = 0.0
+    @variables w(t_nounits) = 0.0
+
+    received = Ref{Any}(:never_called)
+    factory = function (parent_sys, extra_needed = nothing)
+        received[] = extra_needed
+        return nothing # a factory may decline to produce an event
+    end
+    wsys = System([D_nounits(w) ~ c], t_nounits, [w], [c]; name = :wsys,
+        metadata = Dict(SysDiscreteEvent => factory))
+
+    sys = convert(System, couple(wsys))
+
+    # The 2-arg method is still preferred; with no DomainInfo the keep-set is
+    # empty but not `nothing` (which would mean the 1-arg default was used).
+    @test received[] !== nothing
+    @test received[] == Any[]
+    @test length(ModelingToolkit.get_discrete_events(sys)) == 0
 end
 
 end

--- a/test/coupled_system_test.jl
+++ b/test/coupled_system_test.jl
@@ -522,3 +522,60 @@ end
     eq_strs2 = sort([string(eq) for eq in equations(sys2)])
     @test eq_strs2 == unique(eq_strs2)
 end
+
+
+# ----------------------------------------------------------------------------
+# callback_vars + discrete-event factory forwarding contract: callback-only
+# variables must reach the prune factory's keep-set.
+# ----------------------------------------------------------------------------
+struct _MockPBLCallback end
+struct _Bare end
+EarthSciMLBase.get_needed_vars(::_MockPBLCallback, sys, mtk_sys, domain) = [:A1_PBLH_marker]
+
+@testset "callback_vars + 2-arg factory forwarding" begin
+    import Dates
+
+_dom = EarthSciMLBase.DomainInfo(Dates.DateTime(2016, 1, 1), Dates.DateTime(2016, 1, 2);
+    lonrange = deg2rad(-90):deg2rad(1):deg2rad(-88),
+    latrange = deg2rad(30):deg2rad(1):deg2rad(32),
+    levrange = 1:2, u_proto = zeros(Float64, 1, 1, 1, 1))
+
+@testset "callback_vars gathers advertised vars; skips method-less callbacks" begin
+    # Standalone unit on callback_vars using a hand-built CoupledSystem shell.
+    # (domain/mtk_sys are only forwarded to get_needed_vars, which ignores them here.)
+    cs = CoupledSystem(EarthSciMLBase.ModelingToolkit.AbstractSystem[],
+        EarthSciMLBase.ModelingToolkit.PDESystem[], nothing, Any[],
+        EarthSciMLBase.Operator[], EarthSciMLBase.DECallback[],
+        Any[_MockPBLCallback()])
+    @test EarthSciMLBase.callback_vars(cs, nothing, _dom) == [:A1_PBLH_marker]
+
+    # a callback with NO get_needed_vars method is silently skipped (not an error)
+    cs2 = CoupledSystem(EarthSciMLBase.ModelingToolkit.AbstractSystem[],
+        EarthSciMLBase.ModelingToolkit.PDESystem[], nothing, Any[],
+        EarthSciMLBase.Operator[], EarthSciMLBase.DECallback[],
+        Any[_Bare(), _MockPBLCallback()])
+    @test EarthSciMLBase.callback_vars(cs2, nothing, _dom) == [:A1_PBLH_marker]
+end
+
+@testset "factory dispatch: 2-arg receives extra_needed; 1-arg unchanged" begin
+    # Mirror the convert() call site: factories that accept (parent, extra_needed)
+    # get the forwarded set; legacy 1-arg factories are called with parent only.
+    seen = Ref{Any}(:untouched)
+    two_arg = function (parent_sys, extra_needed = nothing)
+        seen[] = extra_needed
+        return nothing
+    end
+    one_arg = function (parent_sys)
+        return :legacy_ran
+    end
+    extra_needed = [:A1_PBLH_marker, :op_var]
+    # the exact selector used at coupled_system.jl:317
+    r2 = applicable(two_arg, nothing, extra_needed) ?
+         two_arg(nothing, extra_needed) : two_arg(nothing)
+    r1 = applicable(one_arg, nothing, extra_needed) ?
+         one_arg(nothing, extra_needed) : one_arg(nothing)
+    @test seen[] == extra_needed        # 2-arg factory received the keep-set
+    @test r1 == :legacy_ran             # 1-arg factory called via the fallback branch
+end
+
+end


### PR DESCRIPTION

**default-behavior change (safe default) · companion to the EarthSciData callback-aware interpolator-prune PR**

## Motivation
Discrete-event / init-callback factories attached to a `CoupledSystem` are invoked with only the compiled system. Nothing in the build tells a downstream component which variables operators and callbacks consume **out-of-band** of the compiled equations — so any consumer that optimizes based on "appears in an equation" (e.g. EarthSciData's interpolator live-mask prune) silently starves callback-only inputs.

Root-cause incident: the auto-prune dropped GEOSFP `A1₊PBLH` — read solely by `PBLMixingCallback`'s observed function, present in no compiled equation — leaving a zero-sentinel buffer: `pblh≈0 → imix=1 →` no PBL vertical mixing → surface emissions trapped in level 1 → **O3 titration collapse** at the surface. The vertical fingerprint that identifies this failure is emitted species accumulating in the lowest level while upper levels stay frozen at their initial profile; the only defect is the starved callback input, so the fix is to let callbacks advertise their out-of-band reads and keep those inputs live through the prune.

## Change
- New gatherer `callback_vars(sys, mtk_sys, domain)`, mirroring the existing `operator_vars` but over `sys.init_callbacks`: a callback advertises the variables it reads outside the equation system by adding a method of `get_needed_vars` — the same declaration interface operators already use. Callbacks without such a method are skipped, so existing components need no change.
- The coupled-system build collects the operator variables ∪ `callback_vars(...)` into a keep-set and forwards it to discrete-event factories via a two-call-convention protocol:
  - **1-arg factories** (all existing code) are called exactly as before — unchanged.
  - **2-arg factories** receive `(sys, needed_vars)` and can act on the keep-set (dispatch is applicability-checked, so opting in is just adding a method).
- `docs/src/operator.md`: new section documenting the protocol and the 2-arg factory convention.

## Compatibility impact
Default-behavior change, safe-default framing: no existing 1-arg factory changes behavior; the new forwarding activates only for factories that define a 2-arg method (`applicable`-checked at the call site, so opting in is just adding a method). The declaration side introduces no new mechanism either — it extends the `get_needed_vars` interface operators already implement to init-callbacks, closing the asymmetry that caused the incident (operators could advertise out-of-band reads; callbacks could not). The behavioral effect lands in the **companion** EarthSciData callback-aware interpolator-prune PR, whose legacy 1-arg path degrades to "don't prune" rather than "prune wrongly" — no intermediate broken state in any merge order.

## Validation
- Contract testset (`coupled_system_test.jl`): `callback_vars` gathers a mock callback's advertised variable (one appearing in no equation) into the keep-set, and skips a callback without a `get_needed_vars` method (not an error).
- **Integration testsets through the real call site**: a coupled system whose component carries a 2-arg discrete-event factory receives the `operator_vars ∪ callback_vars` keep-set from `convert(System, ::CoupledSystem)` itself (content and order asserted); a legacy 1-arg factory keeps working unchanged alongside it; both factories' events land in the converted system's discrete events; and without a `DomainInfo` the 2-arg method still wins with an empty (non-`nothing`) keep-set.
- Full-suite `Pkg.test` on this branch vs an upstream/main baseline: failure set identical to the baseline (the two grid-solve tests upstream marked broken on Julia 1.12.5+) — i.e. no existing behavior changed — with all new testsets green (Coupled System 99 pass / 0 fail).
- End-to-end effect (callback-only met fields kept live through the prune) is regression-tested on real interpolators in the companion EarthSciData callback-aware interpolator-prune PR.

## Cost note
`convert` now computes the `operator_vars ∪ callback_vars` keep-set whenever the coupled system carries a `DomainInfo`, even when no 2-arg factory consumes it — a small one-time metadata walk per build, not on any solver hot path.

## Dependencies
None. Merge **before** the EarthSciData callback-aware interpolator-prune PR, which consumes the keep-set on its 2-arg path. Until then Data's 1-arg legacy path safely skips pruning.

## Limitations
The protocol is declarative — a component must add a `get_needed_vars` method for its callback to be protected. With the companion prune PR's safe default, a missing implementation costs performance (interpolators stay live and lazy-load), never correctness.


## Figure

![The prune failure this protocol prevents: without a callback keep-set, prune drops a callback's inputs -> PBL mixing goes silent -> surface O3 titrated](https://cdn.jsdelivr.net/gh/xk-y/EarthSciMLBase.jl@pr-assets/callback_prune_mechanism.png)

The `callback_vars` keep-set is the Base half of the callback-aware prune fix (companion PR in EarthSciData). Illustrative mechanism (no run value asserted; the forwarding itself is integration-tested through `convert(System, ...)` above): without a keep-set, a downstream prune can drop the fields a discrete-event callback needs, silently disabling it.

---

*Part of the coordinated cross-repo update tracked in EarthSciML/GasChem.jl#225.*
